### PR TITLE
Solved an error caused by LuaSocket by allowing it to pollute the global variables.

### DIFF
--- a/mod_auth_privacyidea/mod_auth_privacyidea.lua
+++ b/mod_auth_privacyidea/mod_auth_privacyidea.lua
@@ -10,8 +10,10 @@
 local log = module._log;
 local new_sasl = require "util.sasl".new;
 local json = require "util.json";
+prosody.unlock_globals()
 local https = require "ssl.https";
 local ltn12 = require("ltn12")
+prosody.lock_globals()
 local options = module:get_option("privacyidea_config");
 local server_url = options and options.server;
 assert(server_url, "No privacyIDEA server URL provided");


### PR DESCRIPTION
Prosody was throwing me this error when I use this module :

```

Jul 13 18:30:27 modulemanager   error   Error initializing module 'auth_privacyidea' on 'jitest.fatihmalakci.com': /usr/local/share/lua/5.2/ltn12.lua:16: Attempt to set a global: ltn12 = table: 0x562b4449dde0
stack traceback:
        [C]: in function 'error'
        /usr/lib/prosody/util/startup.lua:339: in function '__newindex'
        /usr/local/share/lua/5.2/ltn12.lua:16: in main chunk
        [C]: in function '_real_require'
        /usr/lib/prosody/util/startup.lua:144: in function 'require'
        /usr/share/lua/5.2/ssl/https.lua:11: in main chunk
        [C]: in function '_real_require'
        /usr/lib/prosody/util/startup.lua:144: in function 'require'
        /usr/lib/prosody/modules/mod_auth_privacyidea.lua:13: in main chunk
        [C]: in function 'xpcall'
        /usr/lib/prosody/core/modulemanager.lua:178: in function 'do_load_module'
        /usr/lib/prosody/core/modulemanager.lua:256: in function 'load'
        /usr/lib/prosody/core/usermanager.lua:67: in function '?'
        /usr/lib/prosody/util/events.lua:79: in function </usr/lib/prosody/util/events.lua:75>
        (...tail calls...)
        /usr/lib/prosody/core/hostmanager.lua:108: in function 'activate'
        /usr/lib/prosody/core/hostmanager.lua:58: in function '?'
        /usr/lib/prosody/util/events.lua:79: in function </usr/lib/prosody/util/events.lua:75>
        (...tail calls...)
        /usr/lib/prosody/util/startup.lua:330: in function 'prepare_to_start'
        /usr/lib/prosody/util/startup.lua:551: in function 'f'
        /usr/lib/prosody/util/async.lua:139: in function 'func'
        /usr/lib/prosody/util/async.lua:127: in function </usr/lib/prosody/util/async.lua:125>
```

This error happens because LuaSocket tries to pollute global variables but it can't, by unlocking globals before importing the luasockets and locking afterwards I managed to solve the error. 
